### PR TITLE
error management & allPluginsLoadedEvent

### DIFF
--- a/lib/plugin-loader.js
+++ b/lib/plugin-loader.js
@@ -39,20 +39,39 @@ exports.PluginLoader = function(modulePath) {
 
 util.inherits(exports.PluginLoader, events.EventEmitter);
 
+exports.PluginLoader.prototype.on = function(event, handler) {
+
+	// we should check if calling site is listening
+	// for 'error' event to avoid unhandled error
+	if (event === 'error') {
+		this._errorWillBeHandled = true;
+	}
+
+	// delegate to EventEmitter
+	return events.EventEmitter.prototype.on.call(this, event, handler);
+}
+
 /**
  * Discovers new/removed plugins and loads/unloads them.
  */
-exports.PluginLoader.prototype.discover = function() {
+exports.PluginLoader.prototype.discover = function(emitAllPluginsLoaded) {
 	var pluginLoader = this;
 	var allFoundModules = [];
 	var scannedDirCount = 0;
 	var pluginsLoading = 0;
+	var errorsOccured = [];
+
+
 	this.modulePath.forEach(function(moduleDirectory) {
 		fs.readdir(moduleDirectory, function(err, files) {
 			if (err) {
-				return pluginLoader.emit('error',err);
+				if (pluginLoader._errorWillBeHandled) {
+					pluginLoader.emit('error',err);
+				}
+				return errorsOccured.push(err);
 			}
 			pluginsLoading += files.length;
+
 			files.forEach(function(moduleName) {
 				if (moduleName.charAt(0) != '.') {
 					allFoundModules.push(moduleName);
@@ -62,13 +81,25 @@ exports.PluginLoader.prototype.discover = function() {
 							try {
 								loadModule(pluginLoader, moduleDirectory, moduleName);
 							} catch (err) {
-								return pluginLoader.emit('error',err);
+
+								if (pluginLoader._errorWillBeHandled) {
+									pluginLoader.emit('error',err);
+								}
+								return errorsOccured.push(err);
+
+							} finally {
+
+								// plugins loading should decrease also
+								// when errors occurs
+
+								pluginsLoading--;
+								if (emitAllPluginsLoaded && pluginsLoading === 0) {
+									var errors = errorsOccured.length === 0 ? undefined : errorsOccured;
+									pluginLoader.emit('allPluginsLoaded', errors);
+								}
 							}
 
-							pluginsLoading--;
-							if (pluginsLoading === 0) {
-								pluginLoader.emit('allPluginsLoaded');
-							}
+
 						}.bind(undefined));
 					}
 				}

--- a/lib/plugin-loader.js
+++ b/lib/plugin-loader.js
@@ -32,7 +32,7 @@ var path = require('path');
  * @param {Array} modulePath
  */
 exports.PluginLoader = function(modulePath) {
-  events.EventEmitter.call(this);	
+  events.EventEmitter.call(this);
   Object.defineProperty(this, 'loadedModules', { value: {} });
   Object.defineProperty(this, 'modulePath', { value: modulePath });
 }
@@ -46,25 +46,32 @@ exports.PluginLoader.prototype.discover = function() {
 	var pluginLoader = this;
 	var allFoundModules = [];
 	var scannedDirCount = 0;
-	
+	var pluginsLoading = 0;
 	this.modulePath.forEach(function(moduleDirectory) {
 		fs.readdir(moduleDirectory, function(err, files) {
+			pluginsLoading += files.length;
 			files.forEach(function(moduleName) {
 				if (moduleName.charAt(0) != '.') {
 					allFoundModules.push(moduleName);
-					
+
 					if (pluginLoader.loadedModules[moduleName] === undefined) {
-						process.nextTick(loadModule.bind(undefined, pluginLoader, moduleDirectory, moduleName));
+						process.nextTick(function(){
+							loadModule(pluginLoader, moduleDirectory, moduleName);
+							pluginsLoading--;
+							if (pluginsLoading === 0) {
+								pluginLoader.emit('allPluginsLoaded');
+							}
+						}.bind(undefined));
 					}
 				}
 			});
-			
+
 			scannedDirCount++;
-			
+
 			if (scannedDirCount == pluginLoader.modulePath.length) {
 				detectRemovedModules(pluginLoader, allFoundModules);
 			}
-		});		
+		});
 	});
 }
 
@@ -73,38 +80,38 @@ exports.PluginLoader.prototype.discover = function() {
  */
 exports.PluginLoader.prototype.startMonitoring = function() {
 	var pluginLoader = this;
-	
+
 	if (this._watchers != null) {
 		return;
 	}
-	
+
 	this._watchers = [];
 	this.modulePath.forEach(function(moduleDirectory) {
-		// the watch method is documented not to be reliably 
+		// the watch method is documented not to be reliably
 		// report the filename argument, so we ignore it and start
 		// a full blown discovery as soon as something happens
 		pluginLoader._watchers.push(fs.watch(moduleDirectory, { persistent: false }, function(event, filename) {
 			pluginLoader.discover();
 		}));
 	});
-  
+
   this.discover();
 }
 
-/** 
+/**
  * Stops monitoring.
  */
 exports.PluginLoader.prototype.stopMonitoring = function() {
 	var pluginLoader = this;
-	
+
 	if (this._watchers == null) {
 		return;
 	}
-	
+
 	this._watchers.forEach(function(watcher) {
 		watcher.close();
 	});
-	
+
 	this._watchers = null;
 }
 
@@ -118,11 +125,11 @@ function detectRemovedModules(pluginLoader, allFoundModules) {
 
 function loadModule(pluginLoader, moduleDirectory, moduleName) {
 	var loadedPlugin = require(path.join(moduleDirectory, moduleName));
-	
+
 	if (typeof(loadedPlugin.load) == 'function') {
 		loadedPlugin.load();
 	}
-	
+
 	pluginLoader.loadedModules[moduleName] = loadedPlugin;
 	pluginLoader.emit('pluginLoaded', moduleName, loadedPlugin);
 }
@@ -130,10 +137,10 @@ function loadModule(pluginLoader, moduleDirectory, moduleName) {
 function unloadModule(pluginLoader, moduleName) {
 	var unloadedPlugin = pluginLoader.loadedModules[moduleName];
 	delete pluginLoader.loadedModules[moduleName];
-	
+
 	if (typeof(unloadedPlugin.unload) == 'function') {
 		unloadedPlugin.unload();
 	}
-	
-	pluginLoader.emit('pluginUnloaded', moduleName, unloadedPlugin);	
+
+	pluginLoader.emit('pluginUnloaded', moduleName, unloadedPlugin);
 }

--- a/lib/plugin-loader.js
+++ b/lib/plugin-loader.js
@@ -49,6 +49,9 @@ exports.PluginLoader.prototype.discover = function() {
 	var pluginsLoading = 0;
 	this.modulePath.forEach(function(moduleDirectory) {
 		fs.readdir(moduleDirectory, function(err, files) {
+			if (err) {
+				return pluginLoader.emit('error',err);
+			}
 			pluginsLoading += files.length;
 			files.forEach(function(moduleName) {
 				if (moduleName.charAt(0) != '.') {
@@ -56,7 +59,12 @@ exports.PluginLoader.prototype.discover = function() {
 
 					if (pluginLoader.loadedModules[moduleName] === undefined) {
 						process.nextTick(function(){
-							loadModule(pluginLoader, moduleDirectory, moduleName);
+							try {
+								loadModule(pluginLoader, moduleDirectory, moduleName);
+							} catch (err) {
+								return pluginLoader.emit('error',err);
+							}
+
 							pluginsLoading--;
 							if (pluginsLoading === 0) {
 								pluginLoader.emit('allPluginsLoaded');

--- a/test/bad_plugins/bad-module.js
+++ b/test/bad_plugins/bad-module.js
@@ -1,0 +1,1 @@
+this is an invalid module

--- a/test/plugin-loader.js
+++ b/test/plugin-loader.js
@@ -31,7 +31,7 @@ describe('PluginLoader', function() {
   var staticPluginFolder = path.join(__dirname, 'test_plugins');
   var dynamicPluginFolder = path.join(__dirname, 'test_plugins_dynamic');
   var pluginFolders = [ staticPluginFolder, dynamicPluginFolder ];
-  
+
   describe('#PluginLoader', function() {
     it('it should create a PluginLoader object inheriting from EventEmitter and with no loaded modules and given module path', function() {
 			var loader = new PluginLoader(pluginFolders);
@@ -40,61 +40,71 @@ describe('PluginLoader', function() {
       loader.modulePath.should.deep.equal(pluginFolders);
     });
   });
-  
+
   describe('#discover', function() {
     it('it should load all plugins from the test_plugins directory', function(done) {
 			var loader = new PluginLoader(pluginFolders);
       var plugin1Loaded = false;
       var plugin2Loaded = false;
-      
+
       loader.on('pluginLoaded', function(pluginName, plugin) {
         pluginName.should.match(/^plugin1$|^plugin2$/);
-        
+
         if (pluginName == 'plugin1') {
           plugin1Loaded = true;
-          plugin.hasBeenLoaded.should.equal(true);         
+          plugin.hasBeenLoaded.should.equal(true);
         } else if (pluginName == 'plugin2') {
           plugin2Loaded = true;
-          plugin.hasBeenUnloaded.should.equal(false); 
+          plugin.hasBeenUnloaded.should.equal(false);
         }
-                
+
         if (plugin1Loaded && plugin2Loaded) {
           done();
         }
       });
-      
+
       loader.discover();
     });
-    
+
+    it('it should emit `allPluginsLoaded` when all plugins are loaded', function(done) {
+      var loader = new PluginLoader(pluginFolders);
+
+      loader.on('allPluginsLoaded', function() {
+        done();
+      });
+
+      loader.discover();
+    });
+
     it('it should unload all plugins removed from the test_plugin folder', function(done) {
 			var loader = new PluginLoader(pluginFolders);
-      loader.discover();      
-      
+      loader.discover();
+
       var plugin1Unloaded = false;
       var plugin2Unloaded = false;
 
       loader.on('pluginUnloaded', function(pluginName, plugin) {
         pluginName.should.match(/^plugin1$|^plugin2$/);
-        
+
         if (pluginName == 'plugin1') {
           plugin1Unloaded = true;
           plugin.hasBeenLoaded.should.equal(true);
         } else if (pluginName == 'plugin2') {
           plugin2Unloaded = true;
-          plugin.hasBeenUnloaded.should.equal(true); 
+          plugin.hasBeenUnloaded.should.equal(true);
         }
-                
+
         if (plugin1Unloaded && plugin2Unloaded) {
           done();
         }
       });
-      
+
       // we change the loader path to remove both plugins without changing the file system
-      loader.modulePath[0] = loader.modulePath[1]; 
+      loader.modulePath[0] = loader.modulePath[1];
       loader.discover();
     });
   });
-  
+
   // Temporary disable for Travis Build until problem solved/mocks implemented.
   /*describe('#startMonitoring', function() {
     function removeLinks() {
@@ -105,45 +115,45 @@ describe('PluginLoader', function() {
         //ignore
       }
     }
-    
+
     beforeEach(removeLinks);
     afterEach(removeLinks);
-    
+
     it('it should detect new modules in the test_plugins_dynamics folder', function(done) {
 			var loader = new PluginLoader([dynamicPluginFolder]);
 
       loader.on('pluginLoaded', function(pluginName, plugin) {
-        pluginName.should.equal('plugin1');        
+        pluginName.should.equal('plugin1');
         plugin.hasBeenLoaded.should.equal(true);
         loader.stopMonitoring();
-        fs.unlinkSync(path.join(dynamicPluginFolder, pluginName));         
+        fs.unlinkSync(path.join(dynamicPluginFolder, pluginName));
         done();
       });
-      
+
       loader.startMonitoring();
       fs.linkSync(path.join(staticPluginFolder, 'plugin1'), path.join(dynamicPluginFolder, 'plugin1'));
     });
-    
+
     it('it should detect removed modules from the test_plugins_dynamics folder', function(done) {
 			var loader = new PluginLoader([dynamicPluginFolder]);
       fs.linkSync(path.join(staticPluginFolder, 'plugin2'), path.join(dynamicPluginFolder, 'plugin2'));
-      
+
       loader.on('pluginLoaded', function(pluginName, plugin) {
         loader.startMonitoring();
         fs.unlinkSync(path.join(dynamicPluginFolder, 'plugin2'));
       });
-      
+
       loader.discover();
 
       loader.on('pluginUnloaded', function(pluginName, plugin) {
-        pluginName.should.equal('plugin2');   
-        plugin.hasBeenUnloaded.should.equal(true);     
+        pluginName.should.equal('plugin2');
+        plugin.hasBeenUnloaded.should.equal(true);
         loader.stopMonitoring();
         done();
       });
     });
   });*/
-  
+
   describe('#stopMonitoring', function() {
     it('it should stop detecting changes in the test_plugins folder', function() {
 			var loader = new PluginLoader([staticPluginFolder]);

--- a/test/plugin-loader.js
+++ b/test/plugin-loader.js
@@ -30,6 +30,7 @@ describe('PluginLoader', function() {
   var fs = require('fs');
   var staticPluginFolder = path.join(__dirname, 'test_plugins');
   var dynamicPluginFolder = path.join(__dirname, 'test_plugins_dynamic');
+  var badPluginFolder = path.join(__dirname, 'bad_plugins');
   var pluginFolders = [ staticPluginFolder, dynamicPluginFolder ];
 
   describe('#PluginLoader', function() {
@@ -75,6 +76,29 @@ describe('PluginLoader', function() {
 
       loader.discover();
     });
+
+    it('it should emit `error` when error are catch loading directories', function(done) {
+      var loader = new PluginLoader(['una strana directory']);
+
+      loader.on('error', function(err) {
+        err.code.should.equal('ENOENT');
+        done();
+      });
+
+      loader.discover();
+    });
+
+    it('it should emit `error` when error are catch loading modules', function(done) {
+      var loader = new PluginLoader([badPluginFolder]);
+
+      loader.on('error', function(err) {
+        err.should.be.instanceOf(SyntaxError);
+        done();
+      });
+
+      loader.discover();
+    });
+
 
     it('it should unload all plugins removed from the test_plugin folder', function(done) {
 			var loader = new PluginLoader(pluginFolders);

--- a/test/plugin-loader.js
+++ b/test/plugin-loader.js
@@ -67,14 +67,41 @@ describe('PluginLoader', function() {
       loader.discover();
     });
 
-    it('it should emit `allPluginsLoaded` when all plugins are loaded', function(done) {
+    it('it should emit `allPluginsLoaded` when all plugins are loaded when discover emitAllPluginsLoaded argument is true', function(done) {
       var loader = new PluginLoader(pluginFolders);
 
-      loader.on('allPluginsLoaded', function() {
+      loader.on('allPluginsLoaded', function(errorsOccured) {
+        chai.equal(errorsOccured, undefined);
         done();
       });
 
-      loader.discover();
+      loader.discover(true);
+    });
+
+    it('it should not emit `allPluginsLoaded` when discover emitAllPluginsLoaded argument is falsy', function(done) {
+      var loader = new PluginLoader(pluginFolders);
+
+      loader.on('allPluginsLoaded', function(errorsOccured) {
+        done(new Error('allPluginsLoaded should not be emitted.'));
+      });
+
+      loader.discover(undefined);
+
+      setTimeout(done, 200);
+    });
+
+    it('allPluginsLoaded event errorsOccured argument should contains occurred events', function(done) {
+      var loader = new PluginLoader(['una strana directory', badPluginFolder]);
+
+      loader.on('allPluginsLoaded', function(errorsOccured) {
+        errorsOccured.should.be.an('array');
+        errorsOccured.length.should.equal(2);
+        errorsOccured[0].code.should.equal('ENOENT');
+        errorsOccured[1].should.be.instanceOf(SyntaxError);
+        done();
+      });
+
+      loader.discover(true);
     });
 
     it('it should emit `error` when error are catch loading directories', function(done) {
@@ -98,6 +125,8 @@ describe('PluginLoader', function() {
 
       loader.discover();
     });
+
+
 
 
     it('it should unload all plugins removed from the test_plugin folder', function(done) {


### PR DESCRIPTION
I add emission of allPluginsLoadedEvent when all plugins are successfully loaded. I need to know 
that the load process end because some plugins of my application need to do some actions when all other plugin are available.

By the way, I also add error managent, both to directory load and module requires.

I add some test for both features.

Some doubts I have:
- do you think that shoud be better to avoid allPluginsLoaded emission in case of error (I'm actually checking this on call site)
- do you think it could be useful to emit the event after `detectRemovedModules` finished?
- how do you prefer to deal with `startMonitoring` regarding to the new event emission? (I'm actually not using this feature)
